### PR TITLE
Added Missing Translations to Photon Mod Config Menu.

### DIFF
--- a/src/main/resources/assets/photon/lang/en_us.json
+++ b/src/main/resources/assets/photon/lang/en_us.json
@@ -1,4 +1,11 @@
 {
+  "photon.configuration.enable_bloom": "Enable Bloom",
+  "photon.configuration.bloom_mip_level": "Bloom mip level",
+  "photon.configuration.bloom_threshold": "Bloom Threshold",
+  "photon.configuration.bloom_intensity": "Bloom Intensity",
+  "photon.configuration.enable_bloom_with_iris_shader": "Enable Bloom with Iris shader",
+  "photon.configuration.iris_shader_compatible_mode": "Iris Shader compatible mode",
+
   "ldlib.gui.editor.register.editor.fx.fxproj": "FX Project",
   "ldlib.gui.editor.register.editor.fx.particle_info": "Particle Information",
   "ldlib.gui.editor.group.particles": "particles",

--- a/src/main/resources/assets/photon/lang/zh_cn.json
+++ b/src/main/resources/assets/photon/lang/zh_cn.json
@@ -1,4 +1,11 @@
 {
+    "photon.configuration.enable_bloom": "Enable Bloom",
+    "photon.configuration.bloom_mip_level": "Bloom mip level",
+    "photon.configuration.bloom_threshold": "Bloom Threshold",
+    "photon.configuration.bloom_intensity": "Bloom Intensity",
+    "photon.configuration.enable_bloom_with_iris_shader": "Enable Bloom with Iris shader",
+    "photon.configuration.iris_shader_compatible_mode": "Iris Shader compatible mode",
+
     "ldlib.gui.editor.register.editor.fx.fxproj": "特效项目",
     "ldlib.gui.editor.register.editor.fx.particle_info": "粒子信息",
     "ldlib.gui.editor.group.particles": "粒子组",


### PR DESCRIPTION
Changed Files Include:
en_us.json
zh_cn.json  Note Added translations are english they need to be translated to Chinese Simplified

Translations Added:
  "photon.configuration.enable_bloom": "Enable Bloom",
  "photon.configuration.bloom_mip_level": "Bloom mip level",
  "photon.configuration.bloom_threshold": "Bloom Threshold",
  "photon.configuration.bloom_intensity": "Bloom Intensity",
  "photon.configuration.enable_bloom_with_iris_shader": "Enable Bloom with Iris shader",
  "photon.configuration.iris_shader_compatible_mode": "Iris Shader compatible mode",